### PR TITLE
Feat/parse input

### DIFF
--- a/app/commands/parse_graph_data.rb
+++ b/app/commands/parse_graph_data.rb
@@ -1,0 +1,14 @@
+class ParseGraphData < PowerTypes::Command.new(:data)
+  def perform
+    @graph = @data["metroStations"].map(&:symbolize_keys)
+    @graph.each do |hash|
+      if hash[:color].blank?
+        hash[:color] = 0
+      end
+    end
+    @graph.inject({}) do |graph, station|
+      graph[station[:name]] = station
+      graph
+    end
+  end
+end

--- a/app/commands/parse_graph_data.rb
+++ b/app/commands/parse_graph_data.rb
@@ -1,11 +1,6 @@
 class ParseGraphData < PowerTypes::Command.new(:data)
   def perform
     @graph = @data["metroStations"].map(&:symbolize_keys)
-    @graph.each do |hash|
-      if hash[:color].blank?
-        hash[:color] = 0
-      end
-    end
     @graph.inject({}) do |graph, station|
       graph[station[:name]] = station
       graph

--- a/app/commands/schemas/metro_stations.json
+++ b/app/commands/schemas/metro_stations.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "required": ["metroStations"],
+  "properties": {
+    "metroStations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/station"}
+    }
+  },
+  "$defs": {
+    "station": {
+      "type": "object",
+      "required": ["name", "neighbors", "color"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the metro station"
+        },
+        "neighbors": {
+          "type": "array",
+          "description": "The neighbors of the metro station"
+        },
+        "color": {
+          "type": "integer",
+          "enum": [0, 1, 2],
+          "description": "The color of the metro station"
+        }
+      }
+    }
+  }
+}

--- a/app/commands/schemas/metro_stations.json
+++ b/app/commands/schemas/metro_stations.json
@@ -18,11 +18,13 @@
         },
         "neighbors": {
           "type": "array",
+          "default": [],
           "description": "The neighbors of the metro station"
         },
         "color": {
           "type": "integer",
           "enum": [0, 1, 2],
+          "default": 0,
           "description": "The color of the metro station"
         }
       }

--- a/app/commands/schemas/metro_stations.json
+++ b/app/commands/schemas/metro_stations.json
@@ -4,6 +4,7 @@
   "properties": {
     "metroStations": {
       "type": "array",
+      "minItems": 1,
       "items": { "$ref": "#/$defs/station"}
     }
   },

--- a/app/commands/validate_graph_data.rb
+++ b/app/commands/validate_graph_data.rb
@@ -1,0 +1,7 @@
+class ValidateGraphData < PowerTypes::Command.new(:data)
+
+  JSON_SCHEMA = "#{Rails.root}/app/commands/schemas/metro_stations.json"
+  def perform
+    JSON::Validator.validate(JSON_SCHEMA, @data)
+  end
+end

--- a/public/example.json
+++ b/public/example.json
@@ -1,0 +1,49 @@
+{
+  "metroStations": [
+    {
+      "name": "A",
+      "neighbors": ["B"],
+      "color": 0
+    },
+    {
+      "name": "B",
+      "neighbors": ["A", "C"],
+      "color": 0
+    },
+    {
+      "name": "C",
+      "neighbors": ["B", "D", "G"],
+      "color": 0
+    },
+    {
+      "name": "D",
+      "neighbors": ["C", "E"],
+      "color": 0
+    },
+    {
+      "name": "E",
+      "neighbors": ["D", "F"],
+      "color": 0
+    },
+    {
+      "name": "F",
+      "neighbors": ["E", "I"],
+      "color": 0
+    },
+    {
+      "name": "G",
+      "neighbors": ["C", "H"],
+      "color": 1
+    },
+    {
+      "name": "H",
+      "neighbors": ["G", "I"],
+      "color": 2
+    },
+    {
+      "name": "I",
+      "neighbors": ["H", "F"],
+      "color": 1 
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,0 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file

--- a/spec/commands/parse_graph_data_spec.rb
+++ b/spec/commands/parse_graph_data_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe ParseGraphData do
+  def perform
+    described_class.for(data: data)
+  end
+
+  let(:valid_hash) do
+    {
+      "metroStations" => [
+        {
+          "name": "Los heroes",
+          "neighbors": ["Toesca", "Cal y Canto"],
+          "color": 2
+        }
+      ]
+    }
+  end
+
+  let(:output_hash) do
+      {
+       'Los heroes' =>  {
+          name: "Los heroes",
+          neighbors: ["Toesca", "Cal y Canto"],
+          color: 2
+        }
+      }
+  end
+
+  describe 'valid data' do
+    let(:data) { valid_hash}
+    it 'returns parsed hash' do
+      expect(perform).to eq(output_hash)
+    end
+  end
+end

--- a/spec/commands/parse_graph_data_spec.rb
+++ b/spec/commands/parse_graph_data_spec.rb
@@ -5,32 +5,50 @@ describe ParseGraphData do
     described_class.for(data: data)
   end
 
-  let(:valid_hash) do
+  let(:station1) do
     {
-      "metroStations" => [
-        {
-          "name": "Los heroes",
-          "neighbors": ["Toesca", "Cal y Canto"],
-          "color": 2
-        }
-      ]
+      "name": "Los heroes",
+      "neighbors": ["Toesca", "Cal y Canto"],
+      "color": 2
     }
   end
 
-  let(:output_hash) do
-      {
-       'Los heroes' =>  {
-          name: "Los heroes",
-          neighbors: ["Toesca", "Cal y Canto"],
-          color: 2
-        }
-      }
+  let(:station2) do
+    {
+      "name": "Toesca",
+      "neighbors": ["Los heroes", "Rondizzoni"],
+      "color": 1
+    }
   end
 
+  let(:data) { {"metroStations" => [ station1, station2]} }
+
+
   describe 'valid data' do
-    let(:data) { valid_hash}
-    it 'returns parsed hash' do
-      expect(perform).to eq(output_hash)
+    it 'parsed hash contain station names as keys' do
+      expect(perform).to have_key("Toesca")
+      expect(perform).to have_key("Los heroes")
+    end
+
+    it 'parsed stations contain symbolized names' do
+      expect(perform).to include(
+        "Los heroes" => hash_including(name: "Los heroes"),
+        "Toesca" => hash_including(name: "Toesca")
+      )
+    end
+
+    it 'parsed stations contain symbolized colors' do
+      expect(perform).to include(
+        "Los heroes" => hash_including(color: 2),
+        "Toesca" => hash_including(color: 1)
+      )
+    end
+
+    it 'parsed stations contain symbolized neighbor' do
+      expect(perform).to include(
+        "Los heroes" => hash_including(neighbors:  station1[:neighbors]),
+        "Toesca" => hash_including(neighbors: station2[:neighbors])
+      )
     end
   end
 end

--- a/spec/commands/validate_graph_data_spec.rb
+++ b/spec/commands/validate_graph_data_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe ValidateGraphData do
+  def perform
+    described_class.for(data: data)
+  end
+
+  let(:station_json_valid) do
+    {
+      name: "Los heroes",
+      neighbors: ["Toesca", "Cal y Canto"],
+      color: 1
+    }
+  end
+
+  describe 'valid data' do
+    let(:data) { { metroStations: [ station_json_valid ]} }
+    it 'returns true' do
+      expect(perform).to eq(true)
+    end
+  end
+end

--- a/spec/commands/validate_graph_data_spec.rb
+++ b/spec/commands/validate_graph_data_spec.rb
@@ -4,19 +4,102 @@ describe ValidateGraphData do
   def perform
     described_class.for(data: data)
   end
-
-  let(:station_json_valid) do
+  let(:name) { 'Los heroes' }
+  let(:neighbors) { ["Toesca", "Cal y Canto"] }
+  let(:color) { 1 }
+  let(:stations) do
     {
-      name: "Los heroes",
-      neighbors: ["Toesca", "Cal y Canto"],
-      color: 1
+      name: name,
+      neighbors: neighbors,
+      color: color
     }
   end
+  let(:data) { { metroStations: [ stations ]} }
 
-  describe 'valid data' do
-    let(:data) { { metroStations: [ station_json_valid ]} }
-    it 'returns true' do
-      expect(perform).to eq(true)
+  describe 'valid input' do
+    context 'when all inputs are valid and present' do
+      it { expect(perform).to eq(true) }
+    end
+
+    context 'when neighbors are empty list' do
+      let(:neighbors) { [] }
+      it { expect(perform).to eq(true) }
+    end
+  end
+
+  describe 'missing fields' do
+    context 'when color is missing' do
+      let(:stations) { { name: name, neighbors: neighbors } }
+      it { expect(perform).to eq(false) }
+    end
+
+    context 'when neighbor is missing' do
+      let(:stations) { { name: name, color: color } }
+      it { expect(perform).to eq(false) }
+    end
+
+    context 'when name is missing' do
+      let(:stations) { { neighbors: neighbors, color: color } }
+      it { expect(perform).to eq(false) }
+    end
+  end
+
+  describe 'invalid fields' do
+    describe 'invalid name' do
+      context 'when name is nil' do
+        let(:name) { nil }
+        it {expect(perform).to eq(false) }
+      end
+
+      context 'when name is not string' do
+        let(:name) { 3 }
+        it {expect(perform).to eq(false) }
+      end
+    end
+
+    describe 'invalid neighbors' do
+      context 'when neighbors are nil' do
+        let(:neighbors) { nil }
+        it 'returns false' do
+          expect(perform).to eq(false)
+        end
+      end
+    end
+
+    describe 'invalid color' do
+      context 'when color is nil' do
+        let(:color) { nil }
+        it { expect(perform).to eq(false)}
+      end
+
+      context 'when color is not in accepted values' do
+        let(:color) { 3 }
+        it {expect(perform).to eq(false)}
+      end
+    end
+  end
+
+  describe 'invalid object' do
+    context "when metro stations is not object" do
+      context 'when data is nil' do
+        let(:data) { nil }
+        it { expect(perform).to eq(false) }
+      end
+
+      context 'when data is array' do
+        let(:data) { [] }
+        it { expect(perform).to eq(false) }
+      end
+
+      context 'when data is empty object' do
+        let(:data) { {} }
+        it { expect(perform).to eq(false) }
+      end
+
+      context 'when metroStation is empty array' do
+        let(:data) { { metroStations: [] } }
+        it { expect(perform).to eq(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
# Que se esta haciendo

Se agregan dos comandos, generados a partir de la gema `power-types`.

1. `ValidateGraphData`: Este comando valida si es que el JSON de input tiene la estructura correcta de la red de metro.
2. `ParseGraphData`: Este comando convierte el input en un hash mas facil de manipular.

Se testea que ambos comandos produzcan el output deseado